### PR TITLE
Version 1.0.1

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -33,10 +33,11 @@ const makeFilled = (selection) => {
         // Clone node to be filled
         const fillNode = node.clone();
 
-        // Reparent cloned node and set its position
+        // Reparent cloned node and set its position and rotation
         node.parent.appendChild(fillNode);
         fillNode.x = node.x;
         fillNode.y = node.y;
+        fillNode.rotation = node.rotation;
 
         // Remove strokes from cloned node
         fillNode.strokeStyleId = "";

--- a/src/code.ts
+++ b/src/code.ts
@@ -10,6 +10,11 @@ const makeFilled = (selection) => {
 
     // Only process visible nodes
     if (node.visible) {
+      if (node.type === "BOOLEAN_OPERATION") {
+        // Process children of boolean operation nodes
+        makeFilled(node.children);
+      }
+
       if (node.type === "ELLIPSE" || node.type === "POLYGON" || node.type === "STAR" || node.type === "RECTANGLE" || node.type === "VECTOR" || node.type === "BOOLEAN_OPERATION") {
         // Skip node if it is just a line
         if (node.type === "VECTOR" && node.vectorNetwork.segments.length < 2) {
@@ -70,7 +75,7 @@ const makeFilled = (selection) => {
 
         madeFilled = true;
       } else if (node.type === "COMPONENT" || node.type === "FRAME" || node.type === "GROUP" || node.type === "INSTANCE") {
-        // Process the children of boolean operation nodes, components, frames, groups, and instances
+        // Process the children of components, frames, groups, and instances
         makeFilled(node.children);
       } else {
         figma.notify("This layer type is not supported.");

--- a/src/code.ts
+++ b/src/code.ts
@@ -10,7 +10,7 @@ const makeFilled = (selection) => {
 
     // Only process visible nodes
     if (node.visible) {
-      if (node.type === "ELLIPSE" || node.type === "POLYGON" || node.type === "STAR" || node.type === "RECTANGLE" || node.type === "VECTOR") {
+      if (node.type === "ELLIPSE" || node.type === "POLYGON" || node.type === "STAR" || node.type === "RECTANGLE" || node.type === "VECTOR" || node.type === "BOOLEAN_OPERATION") {
         // Skip node if it is just a line
         if (node.type === "VECTOR" && node.vectorNetwork.segments.length < 2) {
           figma.notify("Lines cannot be filled.");
@@ -69,7 +69,7 @@ const makeFilled = (selection) => {
         }
 
         madeFilled = true;
-      } else if (node.type === "BOOLEAN_OPERATION" || node.type === "COMPONENT" || node.type === "FRAME" || node.type === "GROUP" || node.type === "INSTANCE") {
+      } else if (node.type === "COMPONENT" || node.type === "FRAME" || node.type === "GROUP" || node.type === "INSTANCE") {
         // Process the children of boolean operation nodes, components, frames, groups, and instances
         makeFilled(node.children);
       } else {

--- a/src/code.ts
+++ b/src/code.ts
@@ -23,14 +23,12 @@ const makeFilled = (selection) => {
         }
 
         // Skip node if it has no stroke
-        if (node.strokeWeight === 0) {
+        if (node.strokes.length === 0) {
           continue;
         }
 
-        if ("strokes" in node) {
-          // Save first stroke of node
-          strokes = clone(node.strokes[0]);
-        }
+        // Save first stroke of node
+        strokes = clone(node.strokes[0]);
 
         // Clone node to be filled
         const fillNode = node.clone();


### PR DESCRIPTION
- Adds support for filling boolean operation groups that have a stroke
- Filled layers will have the same rotation as their outlined counterparts
- Fixes an issue where the plugin would try to process layers that have no stroke
